### PR TITLE
Modification de la hiérarchie des titres

### DIFF
--- a/docs-fr/server-link.md
+++ b/docs-fr/server-link.md
@@ -9,14 +9,14 @@ ligne ou exécuter des commandes nécessitent de relier votre serveur à votre
 site web, sur Azuriom cela peut être fait de 3 façons différentes :
 
 * Par Ping - **C'est la solution la plus simple, mais aussi la plus limitée** :
-elle permet juste de récupérer les joueurs connectés du serveur
-_(ne permet pas d'exécuter des commandes)_.
+elle permet juste de récupérer les joueurs connectés au serveur
+_(ne permet pas d'exécuter de commandes)_.
 
 * Par Rcon - **C'est la solution intermédiaire**, elle permet de récupérer les informations 
-de du serveur et d'exécuter des commandes.
+de du serveur et d'y exécuter des commandes.
 
 * Par Plugin - **C'est la meilleure solution**, elle permet d'avoir les fonctionnalités du Rcon
-tout en ajoutant des fonctionnalités plus poussées _(exemple : un système de statistique avancé)_.
+tout en ajoutant des fonctionnalités plus poussées _(exemple : un système de statistiques avancées)_.
 
 ### Liaison par Ping
 
@@ -44,7 +44,7 @@ et remplir les informations demandées _(le port Rcon par défaut est `25575`)_.
 #### Qu'est-ce que AzLink ?
 
 AzLink est un plugin de liaison site-serveur spécialement conçu pour et par Azuriom 
-afin de vous permettre de lier un serveur à un site sous Azuriom de façon simple,
+afin de vous permettre de lier un serveur Minecraft à un site sous Azuriom de façon simple,
 rapide et sécurisée.
 
 Actuellement AzLink supporte Bukkit/Spigot, BungeeCord, Sponge et Velocity dans le même plugin.

--- a/docs-fr/server-link.md
+++ b/docs-fr/server-link.md
@@ -1,6 +1,8 @@
 # Liaison Site-Serveur
 
-## Introduction
+## Minecraft
+
+### Introduction
 
 Certaines fonctionnalités comme afficher les joueurs en
 ligne ou exécuter des commandes nécessitent de relier votre serveur à votre
@@ -16,13 +18,13 @@ de du serveur et d'exécuter des commandes.
 * Par Plugin - **C'est la meilleure solution**, elle permet d'avoir les fonctionnalités du Rcon
 tout en ajoutant des fonctionnalités plus poussées _(exemple : un système de statistique avancé)_.
 
-## Liaison par Ping
+### Liaison par Ping
 
 Pour pouvoir lier un serveur avec un site sous Azuriom par ping, 
 il faut juste ajouter un nouveau serveur avec comme type de liaison "Ping"
 et remplir les informations demandées _(le port par défaut de Minecraft est `25565`)_.
 
-## Liaison par Rcon
+### Liaison par Rcon
 
 Pour pouvoir lier un serveur avec un site sous Azuriom par Rcon, il faut:
 
@@ -37,9 +39,9 @@ Pour pouvoir lier un serveur avec un site sous Azuriom par Rcon, il faut:
 1. Vous rendre sur votre site et ajouter un nouveau serveur avec comme type de liaison "Rcon"
 et remplir les informations demandées _(le port Rcon par défaut est `25575`)_.
 
-## Liaison par plugin (AzLink)
+### Liaison par plugin (AzLink)
 
-### Qu'est-ce que AzLink ?
+#### Qu'est-ce que AzLink ?
 
 AzLink est un plugin de liaison site-serveur spécialement conçu pour et par Azuriom 
 afin de vous permettre de lier un serveur à un site sous Azuriom de façon simple,
@@ -48,7 +50,7 @@ rapide et sécurisée.
 Actuellement AzLink supporte Bukkit/Spigot, BungeeCord, Sponge et Velocity dans le même plugin.
 Une version legacy est disponible pour les serveurs utilisant Bukkit 1.7.10.
 
-### Installation
+#### Installation
 
 1. Télécharger AzLink sur [notre site](https://azuriom.com/azlink)
 


### PR DESCRIPTION
Permettra d’ajouter la documentation pour la liaison site-serveur pour les autres jeux que Minecraft en ajoutant un niveau de hiérarchie (h2) pour les différents jeux.